### PR TITLE
Update app.sh to reflect update to openssl-1.0.2d.tar.gz

### DIFF
--- a/app.sh
+++ b/app.sh
@@ -16,7 +16,7 @@ popd
 
 ### OPENSSL ###
 _build_openssl() {
-local VERSION="1.0.2a"
+local VERSION="1.0.2d"
 local FOLDER="openssl-${VERSION}"
 local FILE="${FOLDER}.tar.gz"
 local URL="http://www.openssl.org/source/${FILE}"


### PR DESCRIPTION
The file http://www.openssl.org/source/openssl-1.0.2a.tar.gz returns 404.
Updated app.sh to reflect new package 1.0.2d.tar.gz
